### PR TITLE
Fix typo in the header of deliverable 2

### DIFF
--- a/deliverable2.txt
+++ b/deliverable2.txt
@@ -1,7 +1,7 @@
 CS1699 - Software Testing
 Spring Semester 2014
 
-Deliverable 1
+Deliverable 2
 Assigned 2 FEBRUARY 2014
 Due 17 FEBRUARY 2014
 


### PR DESCRIPTION
I think that you meant to say "deliverable 2" towards the top of [deliverable 2](https://github.com/laboon/CS1699/blob/master/deliverable2.txt). I was a little confused when I first read it.
